### PR TITLE
Fix main menu handler filter

### DIFF
--- a/handlers/client/main_menu.py
+++ b/handlers/client/main_menu.py
@@ -1,4 +1,4 @@
-from aiogram import Router
+from aiogram import Router, F
 from aiogram.types import Message
 from aiogram.fsm.context import FSMContext
 from aiogram.filters.state import StateFilter
@@ -14,7 +14,7 @@ def get_client_main_menu_router():
     logger = setup_logger('bot.client')
     router = Router()
 
-    @router.message(StateFilter(UserStates.main_menu))
+    @router.message(F.text.in_(["🏠 Asosiy menyu", "🏠 Главное меню"]))
     async def main_menu_handler(message: Message, state: FSMContext):
         try:
             user = await get_user_by_telegram_id(message.from_user.id)


### PR DESCRIPTION
## Summary
- activate main menu via message text instead of user state filter
- make filters package importable for tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'filters')*
- `PYTHONPATH=. pytest -q` *(fails: ValueError: BOT_TOKEN environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_686b860c595c8324897f7b56629c1fea